### PR TITLE
[refactor] Update post send mail and Controlled create form dropdowns and dropdown UI polish

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { api } from "@/trpc/react"
-import { useState } from "react"
+import { useMemo, useState } from "react"
+import { useWatch } from "react-hook-form"
 import { useRouter } from "next/navigation"
 import { useSession } from "@/lib/auth-client"
 import { useForm } from "react-hook-form"
@@ -36,7 +37,7 @@ const CreatePage = () => {
     const [imagePreview, setImagePreview] = useState<string | null>(null)
     const [imageFile, setImageFile] = useState<File | null>(null)
     
-    const { handleSubmit, getValues, setValue, formState: { errors } } = useForm<CreatePostWithInterests>({
+    const { handleSubmit, getValues, setValue, control, formState: { errors } } = useForm<CreatePostWithInterests>({
         resolver: zodResolver(CreatePostWithInterestsSchema),
         defaultValues: {
             title: "",
@@ -49,6 +50,24 @@ const CreatePage = () => {
             date: new Date(),
         }
     })
+
+    const watchedActivityTypeId = useWatch({ control, name: "activityTypeId" })
+    const watchedInterestIds = useWatch({ control, name: "interestIds" })
+
+    const activityTypeDropdownLabel = useMemo(
+        () => activityTypes?.find((t) => t.id === watchedActivityTypeId)?.name,
+        [activityTypes, watchedActivityTypeId],
+    )
+
+    const interestMultiLabels = useMemo(
+        () =>
+            watchedInterestIds?.length
+                ? (watchedInterestIds
+                    .map((id) => interests?.find((i) => i.id === id)?.name)
+                    .filter((n): n is string => Boolean(n)) ?? [])
+                : [],
+        [interests, watchedInterestIds],
+    )
 
     const createPost = api.post.create.useMutation({
         onSuccess: (res) => {
@@ -122,6 +141,7 @@ const CreatePage = () => {
                                     icon="type"
                                     isDropdown={true}
                                     typeList={activityTypes?.map((t) => t.name) ?? []}
+                                    dropdownValue={activityTypeDropdownLabel}
                                     className="w-full focus-visible:ring-0"
                                     onDropdownChange={(value) => {
                                         const match = activityTypes?.find((t) => t.name === value)
@@ -135,6 +155,7 @@ const CreatePage = () => {
                                     icon="category"
                                     isMultiDropdown={true}
                                     categoryList={interests?.map((t) => t.name) ?? []}
+                                    multiValue={interestMultiLabels}
                                     className="w-full"
                                     onMultiDropdownChange={(values) => {
                                         const matches = values

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { Button } from "@/components/ui/Button"
+import { cn } from "@/lib/utils"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -40,12 +41,21 @@ export function Dropdown({ children, ...props }: Arguments) {
   return (
     <DropdownMenu onOpenChange={props.onOpenChange}>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" id={props.id} className={"hover:text-white " + props.className}>
-          {displayValue ? <span className="truncate">{displayValue}</span> : children}
+        <Button
+          variant="outline"
+          id={props.id}
+          className={cn(
+            "w-full min-w-0 justify-between gap-2 font-normal text-left hover:bg-background",
+            props.className,
+          )}
+        >
+          <span className="min-w-0 flex-1 truncate text-left">
+            {displayValue ? displayValue : children}
+          </span>
           {props.icon}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className={props.menuContentClassName}>
+      <DropdownMenuContent className={cn("p-1", props.menuContentClassName)}>
         {props?.panelLabel && (
           <>
             <DropdownMenuLabel>{props.panelLabel}</DropdownMenuLabel>
@@ -59,7 +69,7 @@ export function Dropdown({ children, ...props }: Arguments) {
               key={idx}
               className={props.itemClassName}
             >
-              <div className="flex w-full items-center py-1 pl-4">{state}</div>
+              {state}
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { CheckIcon, CheckSquareIcon, ChevronRightIcon, CircleIcon, Square } from "lucide-react"
+import { CheckIcon, ChevronRightIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -42,7 +42,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[10rem] min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[10rem] min-w-0 w-[var(--radix-dropdown-menu-trigger-width)] max-w-[min(100vw-2rem,var(--radix-dropdown-menu-trigger-width))] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
           className
         )}
         {...props}
@@ -93,29 +93,20 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-[#f7dae5] focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pl-2 pr-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "focus:bg-[#f7dae5] focus:text-accent-foreground data-[highlighted]:bg-[#f7dae5] data-[state=checked]:bg-[#f7dae5]/60",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
       {...props}
     >
-      {/* <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+      <span className="pointer-events-none flex size-4 shrink-0 items-center justify-center rounded border border-primary">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-4 bg-primary text-white" />
+          <CheckIcon className="size-3 text-primary" />
         </DropdownMenuPrimitive.ItemIndicator>
-      </span> */}
-      <DropdownMenuPrimitive.ItemIndicator>
-        <div className="w-full pointer-events-none absolute left-0 right-0 top-0 bottom-0 flex items-center pl-2 gap-x-2 bg-[#f7dae5] text-primary z-9999">
-          <CheckIcon className="size-4 bg-primary text-white" />
-          {children}
-        </div>
-      </DropdownMenuPrimitive.ItemIndicator>
-
-      <div className="w-full flex items-center gap-x-2 pl-2 wrap-break-word">
-        <div className="size-4 border-primary border-1"></div>
-        {/* <CheckIcon className="size-4 border-primary border-1" /> */}
-        {children}
-      </div>
+      </span>
+      <span className="min-w-0 flex-1 text-left break-words">{children}</span>
     </DropdownMenuPrimitive.CheckboxItem>
   )
 }
@@ -139,26 +130,20 @@ function DropdownMenuRadioItem({
   return (
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
-      //pr-2 pl-8 gap-2
       className={cn(
-        "focus:bg-[#f7dae5] focus:text-primary relative flex cursor-default items-center py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 justify-center",
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pl-2 pr-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "focus:bg-[#f7dae5] focus:text-primary data-[highlighted]:bg-[#f7dae5] data-[state=checked]:bg-[#f7dae5]/60",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
     >
-      {/* <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+      <span className="pointer-events-none flex size-4 shrink-0 items-center justify-center rounded-full border border-primary">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
+          <span className="block size-2 rounded-full bg-primary" />
         </DropdownMenuPrimitive.ItemIndicator>
-      </span> */}
-      <DropdownMenuPrimitive.ItemIndicator>
-        <div className="w-full pointer-events-none absolute left-0 right-0 top-0 bottom-0 flex bg-[#f7dae5] text-primary z-9999">
-          {children}
-        </div>
-      </DropdownMenuPrimitive.ItemIndicator>
-      <div className="w-full wrap-break-word">
-        {children}
-      </div>
+      </span>
+      <span className="min-w-0 flex-1 text-left break-words">{children}</span>
     </DropdownMenuPrimitive.RadioItem>
   )
 }

--- a/src/components/ui/FormInput.tsx
+++ b/src/components/ui/FormInput.tsx
@@ -33,6 +33,8 @@ interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement>{
     onTextChange?: (value: string) => void,
     onDropdownChange?: (value: string) => void,
     onMultiDropdownChange?: (value: string[]) => void,
+    dropdownValue?: string,
+    multiValue?: string[],
     onDateChange?: (date: Date) => void,
     onTimeChange?: (time: Date) => void, 
 }
@@ -53,6 +55,8 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>((
         onTextChange,
         onDropdownChange,
         onMultiDropdownChange,
+        dropdownValue,
+        multiValue,
         onDateChange,
         onTimeChange,
         ...props}, ref) => {
@@ -66,7 +70,7 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>((
                 </label>
             )}
             <div className="relative w-full">
-                {IconComponent && (
+                {IconComponent && !isMultiDropdown && (
                     <div className={cn("absolute top-3 right-4 w-5 h-5 sm:w-6 sm:h-6 pointer-events-none",(label == null) && "sm:mt-8.5")}>
                         <IconComponent color="#949494" className="w-5 h-5 sm:w-6 sm:h-6"/>
                     </div>
@@ -86,6 +90,7 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>((
                 {isDropdown && (
                     <Dropdown 
                     content={typeList} 
+                    value={dropdownValue}
                     onValueChange={(value) => onDropdownChange?.(value)}
                     className={cn(
                         "h-12 rounded-md border-[#D6D6D6] hover:bg-transparent hover:border-primary/70 focus:ring-0",
@@ -97,6 +102,8 @@ const FormInput = forwardRef<HTMLInputElement, FormInputProps>((
                     <MultiDropdown
                     content={categoryList}
                     panelLabel="เลือกหมวดหมู่"
+                    value={multiValue}
+                    icon={IconComponent ? <IconComponent color="#949494" className="h-5 w-5 shrink-0 sm:h-6 sm:w-6" /> : undefined}
                     onMultiChange={(value) => onMultiDropdownChange?.(value)}
                     className={cn(
                         "h-12 rounded-md border-[#D6D6D6] hover:bg-transparent hover:border-primary/70",

--- a/src/components/ui/MultiDropdown.tsx
+++ b/src/components/ui/MultiDropdown.tsx
@@ -2,9 +2,9 @@
 
 import * as React from "react"
 import { type DropdownMenuCheckboxItemProps } from "@radix-ui/react-dropdown-menu"
-import { z } from "zod";
 import { Button } from "@/components/ui/Button"
-import { ChevronDown } from "lucide-react";
+import { ChevronDown } from "lucide-react"
+import { cn } from "@/lib/utils"
 
 import {
   DropdownMenu,
@@ -26,72 +26,93 @@ type Arguments = {
   icon?: React.ReactNode;
   onOpenChange?: (open: boolean) => void;
   onMultiChange?: (selectedValues: string[]) => void;
-}
+  /** Shown in the trigger when nothing is selected */
+  placeholder?: string;
+  /** Controlled: selected option labels (must match entries in `content`) */
+  value?: string[];
+};
 
 type Checked = DropdownMenuCheckboxItemProps["checked"]
 
-// For me, dropdown doesn't necessarily need to have variant. I also have no idea what the variants should be. 
+function buildCheckedMap(labels: string[] | undefined, content: string[]): Record<string, Checked> {
+  if (!labels?.length) return {};
+  const set = new Set(labels);
+  const next: Record<string, Checked> = {};
+  for (const item of content) {
+    if (set.has(item)) next[item] = true;
+  }
+  return next;
+}
 
-export function MultiDropdown({ children, ...props }: Arguments) {
-  // Instead of using useState for each separate variable, we keep them as an array instead.
-  // const states = props.content.map((s) => {
-  //   return React.useState<Checked>(false);
-  // });
-  const [checkedStates, setCheckedStates] = React.useState<Record<string, Checked>>({});
+export function MultiDropdown({ children, placeholder = "เลือกหมวดหมู่", value, ...props }: Arguments) {
+  const [checkedStates, setCheckedStates] = React.useState<Record<string, Checked>>(() =>
+    buildCheckedMap(value, props.content),
+  );
+
+  const contentKey = props.content.join("\u0000");
+  React.useEffect(() => {
+    if (value === undefined) return;
+    setCheckedStates(buildCheckedMap(value, props.content));
+  }, [value, contentKey]);
 
   const handleCheckedChange = (item: string, isChecked: Checked) => {
     setCheckedStates((prev) => {
-        const updated = { ...prev, [item]: isChecked }
-        
-        const selectedValues = Object.entries(updated)
-            .filter(([_, checked]) => checked)
-            .map(([key]) => key)
-        
-        props.onMultiChange?.(selectedValues)
-        return updated
-    })
-}
+      const updated = { ...prev, [item]: isChecked };
+
+      const selectedValues = Object.entries(updated)
+        .filter(([_, checked]) => checked)
+        .map(([key]) => key);
+
+      // Parent updates (e.g. react-hook-form setValue) must not run inside this updater —
+      // it triggers "Cannot update CreatePage while rendering MultiDropdown".
+      queueMicrotask(() => props.onMultiChange?.(selectedValues));
+      return updated;
+    });
+  };
+
+  const selectedLabels = Object.entries(checkedStates)
+    .filter(([, checked]) => checked)
+    .map(([key]) => key);
+  const summaryText = selectedLabels.length > 0 ? selectedLabels.join(", ") : "";
 
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" id={props.id} className={"hover:text-white " + props.className}>
-          { children }
-          { props.icon }
+        <Button
+          variant="outline"
+          id={props.id}
+          className={cn(
+            "w-full min-w-0 justify-between gap-2 font-normal text-left hover:bg-background",
+            props.className,
+          )}
+        >
+          <span className="min-w-0 flex-1 truncate text-left">
+            {summaryText || children || placeholder}
+          </span>
+          {props.icon ?? <ChevronDown className="size-4 shrink-0 opacity-60" />}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className={props.menuContentClassName}>
-        { props.panelLabel && (<><DropdownMenuLabel>{props.panelLabel}</DropdownMenuLabel>
-        <DropdownMenuSeparator /></>) }
-        {
-          // states.map((state, idx) => {
-          //   return (
-          //     <DropdownMenuCheckboxItem
-          //       checked={state[0]}
-          //       onCheckedChange={state[1]}
-          //       key={idx}
-          //     >
-          //       {props.content[idx]}
-          //     </DropdownMenuCheckboxItem>
-          //   );
-          // })
-          props.content.map((item, idx) => {
-            return (
-              <DropdownMenuCheckboxItem
-                className={props.checkBoxItemClassName}
-                checked={checkedStates[item] ?? false}
-                onCheckedChange={(checked) => handleCheckedChange(item, checked)}
-                key={idx}
-                onSelect={(e) => {
-                  e.preventDefault();
-                }}
-              >
-                {item}
-              </DropdownMenuCheckboxItem>
-            );
-          })
-        }
+      <DropdownMenuContent className={cn("p-1", props.menuContentClassName)}>
+        {props.panelLabel && (
+          <>
+            <DropdownMenuLabel>{props.panelLabel}</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        {props.content.map((item, idx) => (
+          <DropdownMenuCheckboxItem
+            className={props.checkBoxItemClassName}
+            checked={checkedStates[item] ?? false}
+            onCheckedChange={(checked) => handleCheckedChange(item, checked)}
+            key={idx}
+            onSelect={(e) => {
+              e.preventDefault();
+            }}
+          >
+            {item}
+          </DropdownMenuCheckboxItem>
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
-  )
+  );
 }

--- a/src/server/api/service/post.service.ts
+++ b/src/server/api/service/post.service.ts
@@ -1,16 +1,15 @@
 import type { SQL } from "drizzle-orm";
 import { randomUUID } from "crypto";
-import { and, asc, desc, ilike, or, eq } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, inArray, or } from "drizzle-orm";
 import { db } from "@/server/db";
 import { ErrorCategory, ErrorWithCategory, type ErrorOrNull, PostgreSQLError } from "@/utils/error";
 import type { Post, CreatePostRequest } from "@/server/api/dto/post.dto";
 import { post } from "@/server/db/post";
 import { interestXPost } from "@/server/db/interestXPost";
+import { interestXUser } from "@/server/db/interestXUser";
 import { signToken } from "@/server/utils/signedTokens";
 import { user } from "@/server/db/auth-schema";
-import { userXOrganization } from "@/server/db/userXOrganization";
-import { organization } from "@/server/db/organization";
-import { sendMail } from "@/server/utils/mailer";
+import { bulkSendMail } from "@/server/utils/mailer";
 import { ActivityCardMail } from "@/components/ui/ActivityCardMail";
 
 export interface IPostService {
@@ -78,14 +77,25 @@ class PostService implements IPostService {
 		postDescription: string | null | undefined,
 		organizationId: string,
 	): Promise<void> {
-		const subscribers = await db
+		const postInterestRows = await db
+			.select({ interestId: interestXPost.interestId })
+			.from(interestXPost)
+			.where(eq(interestXPost.postId, postId));
+
+		if (postInterestRows.length === 0) return;
+
+		const postInterestIds = postInterestRows.map((r) => r.interestId);
+
+		const recipientRows = await db
 			.select({
 				email: user.email,
 				name: user.name,
 			})
-			.from(userXOrganization)
-			.innerJoin(user, eq(userXOrganization.userId, user.id))
-			.where(and(eq(userXOrganization.organizationId, organizationId), eq(user.isReceiveMail, true)));
+			.from(interestXUser)
+			.innerJoin(user, eq(interestXUser.userId, user.id))
+			.where(and(inArray(interestXUser.interestId, postInterestIds), eq(user.isReceiveMail, true)));
+
+		const subscribers = [...new Map(recipientRows.map((r) => [r.email, r])).values()];
 
 		const orgUser = await db.query.organization.findFirst({
 			where: (organization, { eq }) => eq(organization.id, organizationId),
@@ -99,19 +109,19 @@ class PostService implements IPostService {
 
 		if (subscribers.length === 0) return;
 		const appBase = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000";
-		await Promise.all(
-			subscribers.map((subscriber) => {
-				const token = signToken(postId);
-				const claimLink = `${appBase}/api/calendar/claim?token=${token}`;
-				//temporary design
-				return sendMail({
-					to: subscriber.email,
-					subject: `กิจกรรมใหม่: ${postTitle}`,
-					text: `มีกิจกรรมใหม่ "${postTitle}" คลิกลิงก์เพื่อเพิ่มลงในปฏิทิน: ${claimLink}`,
-					html: ActivityCardMail({ postTitle, postImage, claimLink, postDescription, organizationName }),
-				});
-			}),
-		);
+
+		const messages = subscribers.map((subscriber) => {
+			const token = signToken(postId);
+			const claimLink = `${appBase}/api/calendar/claim?token=${token}`;
+			return {
+				to: subscriber.email,
+				subject: `กิจกรรมใหม่: ${postTitle}`,
+				text: `มีกิจกรรมใหม่ "${postTitle}" คลิกลิงก์เพื่อเพิ่มลงในปฏิทิน: ${claimLink}`,
+				html: ActivityCardMail({ postTitle, postImage, claimLink, postDescription, organizationName }),
+			};
+		});
+
+		await bulkSendMail(messages);
 	}
 	async getAll(): Promise<[Post[], ErrorOrNull]> {
 		const res = await db.query.post

--- a/src/server/utils/mailer.ts
+++ b/src/server/utils/mailer.ts
@@ -23,6 +23,9 @@ export interface SendMailParams {
 	}>;
 }
 
+/** Same fields as {@link SendMailParams}, single `to` — used by {@link bulkSendMail}. */
+export type BulkSendMailItem = Omit<SendMailParams, "to"> & { to: string };
+
 /**
  * Send an email via Resend.
  * Requires at least `text` or `html`.
@@ -41,5 +44,57 @@ export async function sendMail(params: SendMailParams) {
 	} catch (err) {
 		console.error("✉️ Resend error:", err);
 		throw new Error("Unable to send email right now. Please try again later.");
+	}
+}
+
+/** https://resend.com/docs/api-reference/emails/send-batch-emails */
+const RESEND_BATCH_MAX = 100;
+
+/** Free tier: 2 API requests/sec — space single `emails.send` calls (attachments) slightly under that. */
+const RESEND_ATTACHMENT_SEND_GAP_MS = 550;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}
+
+function hasAttachments(item: BulkSendMailItem): boolean {
+	return item.attachments !== undefined && item.attachments.length > 0;
+}
+
+/**
+ * Send many emails: Resend **batch** for messages without attachments; **`sendMail`** per message when attachments are set (batch API does not support attachments).
+ */
+export async function bulkSendMail(items: BulkSendMailItem[]): Promise<void> {
+	if (items.length === 0) return;
+
+	const from = `CUATClub <${process.env.EMAIL_FROM!}>`;
+
+	const withAttachments = items.filter(hasAttachments);
+	const batchable = items.filter((i) => !hasAttachments(i));
+
+	for (let i = 0; i < batchable.length; i += RESEND_BATCH_MAX) {
+		const chunk = batchable.slice(i, i + RESEND_BATCH_MAX);
+		const payload = chunk.map((item): Parameters<typeof resend.batch.send>[0][number] => {
+			const { attachments: _omit, ...rest } = item;
+			return { from, ...rest };
+		});
+
+		try {
+			const res = await resend.batch.send(payload);
+			if (res.error) throw new Error(res.error.message);
+		} catch (err) {
+			console.error("✉️ Resend batch error:", err);
+			throw new Error("Unable to send email right now. Please try again later.");
+		}
+	}
+
+	const lastAttachmentIdx = withAttachments.length - 1;
+	for (let i = 0; i < withAttachments.length; i++) {
+		await sendMail(withAttachments[i]!);
+		if (i !== lastAttachmentIdx) {
+			await sleep(RESEND_ATTACHMENT_SEND_GAP_MS);
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Update send post to send mail to users whose interests match with post interests
- Added staggering between resend api calls to bypass free plan rate limit, and used batch send for mails with no attachments
- Sync activity type and interests fields with the form via `useWatch` and pass controlled labels into `FormInput` (`dropdownValue`, `multiValue`).
- Align `Dropdown` / `MultiDropdown` triggers with shared layout (truncate, full width) and simplify checkbox/radio menu items in `DropdownMenu`.
- Fix React warning when toggling multi-select by deferring `onMultiChange` so the parent is not updated inside `MultiDropdown`'s state updater.

