### PR TITLE
fix: center step indicator on club register success page

### DIFF
--- a/src/app/register/club/_components/StepIndicator.tsx
+++ b/src/app/register/club/_components/StepIndicator.tsx
@@ -20,7 +20,7 @@ export function StepIndicator({ registrationStatus }: StepIndicatorProps) {
   const currentIndex = STATUS_STEP_INDEX[registrationStatus];
 
   return (
-    <div className="border-border flex w-full max-w-full items-center gap-2 rounded-lg border px-4 py-3 md:gap-2 md:px-6 md:py-4">
+    <div className="border-border flex w-full max-w-full items-center justify-center gap-2 rounded-lg border px-4 py-3 md:gap-2 md:px-6 md:py-4">
       {STEPS.map((label, index) => {
         const isDone = index <= currentIndex;
 

--- a/src/app/register/club/_components/StepIndicator.tsx
+++ b/src/app/register/club/_components/StepIndicator.tsx
@@ -20,7 +20,7 @@ export function StepIndicator({ registrationStatus }: StepIndicatorProps) {
   const currentIndex = STATUS_STEP_INDEX[registrationStatus];
 
   return (
-    <div className="border-border flex w-full max-w-full items-center justify-center gap-2 rounded-lg border px-4 py-3 md:gap-2 md:px-6 md:py-4">
+    <div className="border-border inline-flex max-w-full items-center gap-2 rounded-lg border px-4 py-3 md:gap-2 md:px-6 md:py-4">
       {STEPS.map((label, index) => {
         const isDone = index <= currentIndex;
 

--- a/src/app/register/club/success/page.tsx
+++ b/src/app/register/club/success/page.tsx
@@ -7,8 +7,8 @@ import { StepIndicator } from "@/app/register/club/_components/StepIndicator";
 
 export default function ClubRegisterSuccess() {
   return (
-    <div className="flex flex-col bg-white">
-      <main className="flex flex-col px-5 py-5 md:py-10">
+    <div className="flex w-full flex-col bg-white">
+      <main className="w-full px-5 py-5 md:py-10">
         <div className="mx-auto flex w-full max-w-[622px] flex-col items-center gap-6 md:gap-16">
           <div className="flex flex-col items-center gap-6 md:gap-8">
             <div className="flex flex-col items-center gap-2 text-center">


### PR DESCRIPTION
### Issue ID
#117

### Description
Fix step indicator row (`StepIndicator` in `register/club/_components`) not centering horizontally — content was left-packed after the earlier overflow fix added `w-full` without `justify-center`.

### Image
**Desktop:**

<img width="1919" height="909" alt="Screenshot 2026-08-21 191404" src="https://github.com/user-attachments/assets/fef717fb-feb5-4f21-88d1-349f38add15e" />

**Mobile:**

<img width="762" height="855" alt="Screenshot 2026-08-21 191352" src="https://github.com/user-attachments/assets/aa12c1cc-f28e-4141-8b82-de615773aada" />