### PR TITLE
feat: 93 add club registration validation

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -151,18 +151,17 @@ export default function Register() {
                       {...register("confirmPassword")}
                     />
                   </div>
-
-                  <Button type="submit" className="w-full" isLoading={isSubmitting}>
-                    ถัดไป
-                  </Button>
-
-                  <p className="text-foreground-secondary text-center text-sm font-medium">
-                    มีบัญชีอยู่แล้ว?{" "}
-                    <Link href="/login" className="text-primary font-medium">
-                      เข้าสู่ระบบ
-                    </Link>
-                  </p>
                 </div>
+                <Button type="submit" className="w-full" isLoading={isSubmitting}>
+                  ถัดไป
+                </Button>
+
+                <p className="text-foreground-secondary text-center text-sm font-medium">
+                  มีบัญชีอยู่แล้ว?{" "}
+                  <Link href="/login" className="text-primary font-medium">
+                    เข้าสู่ระบบ
+                  </Link>
+                </p>
               </fieldset>
             </form>
           </CardContent>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
 import { User, Users } from "lucide-react";
 
 import {
@@ -14,6 +16,7 @@ import {
   PasswordInput,
 } from "@/components";
 import { ToggleGroup, ToggleGroupItem } from "@/app/register/_components/ToggleGroup";
+import { registerClubSchema, type RegisterClubFormValues } from "./register-schema";
 
 type AccountType = "student" | "club";
 
@@ -23,14 +26,19 @@ export default function Register() {
   // state stays generic for when student registration ships.
   const [accountType, setAccountType] = useState<AccountType>("club");
 
-  const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    // TODO(#93): validate with a zod schema and surface the specific inline
-    // error per field (empty, wrong format, password rules, mismatch, ...).
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterClubFormValues>({ resolver: zodResolver(registerClubSchema) });
+
+  const onSubmit = handleSubmit(() => {
     // TODO(#97/#98): call the register-club API — validates the invitation
-    // code against the email via #67, then creates the User and an empty,
-    // pending Club record.
-  };
+    // code against the email via #67 (surfacing CODE_EMAIL_MISMATCH_MESSAGE /
+    // EMAIL_ALREADY_USED_MESSAGE via setError on the matching field, same as
+    // login-schema.ts's classifyAuthError does for sign-in), then creates the
+    // User and an empty, pending Club record.
+  });
 
   return (
     <div className="flex flex-col bg-white">
@@ -42,117 +50,120 @@ export default function Register() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            {/* gap-8 between the three major sections (toggle block / notice
-                box / fields stack), matching Figma's 32px section rhythm —
-                gap-4 is reserved for spacing *within* the fields stack. */}
-            <form className="flex flex-col gap-8" onSubmit={onSubmit}>
-              <div className="flex flex-col gap-2">
-                <p
-                  id="account-type-label"
-                  className="font-ibm-plex text-foreground text-sm leading-[23px] font-medium md:text-base md:leading-[26px]"
-                >
-                  คุณต้องการลงทะเบียนเป็น
+            <form className="flex flex-col gap-8" onSubmit={onSubmit} noValidate>
+              <fieldset disabled={isSubmitting} className="contents">
+                <div className="flex flex-col gap-2">
+                  <p
+                    id="account-type-label"
+                    className="font-ibm-plex text-foreground text-sm leading-[23px] font-medium md:text-base md:leading-[26px]"
+                  >
+                    คุณต้องการลงทะเบียนเป็น
+                  </p>
+                  <ToggleGroup
+                    type="single"
+                    value={accountType}
+                    onValueChange={(value) => value && setAccountType(value as AccountType)}
+                    aria-labelledby="account-type-label"
+                    className="w-full"
+                  >
+                    <ToggleGroupItem value="student" disabled className="flex-1">
+                      <User aria-hidden="true" />
+                      นักศึกษา
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="club" className="flex-1">
+                      <Users aria-hidden="true" />
+                      ชมรม
+                    </ToggleGroupItem>
+                  </ToggleGroup>
+                </div>
+
+                <p className="border-primary-light bg-primary-lighter/30 text-primary rounded-lg border border-dashed px-3 py-4 text-center text-sm leading-[23px]">
+                  หากต้องการสร้างแอคเคาท์ชมรม กรุณาติดต่อขอรหัสเชิญจากแอดมินผ่านทางไอจี
+                  @cuatclub.chula
                 </p>
-                <ToggleGroup
-                  type="single"
-                  value={accountType}
-                  onValueChange={(value) => value && setAccountType(value as AccountType)}
-                  aria-labelledby="account-type-label"
-                  className="w-full"
-                >
-                  <ToggleGroupItem value="student" disabled className="flex-1">
-                    <User aria-hidden="true" />
-                    นักศึกษา
-                  </ToggleGroupItem>
-                  <ToggleGroupItem value="club" className="flex-1">
-                    <Users aria-hidden="true" />
-                    ชมรม
-                  </ToggleGroupItem>
-                </ToggleGroup>
-              </div>
 
-              <p className="border-primary-light bg-primary-lighter/30 text-primary rounded-lg border border-dashed px-3 py-4 text-center text-sm leading-[23px]">
-                หากต้องการสร้างแอคเคาท์ชมรม กรุณาติดต่อขอรหัสเชิญจากแอดมินผ่านทางไอจี
-                @cuatclub.chula
-              </p>
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-1">
+                    <label
+                      htmlFor="invitationCode"
+                      className="font-ibm-plex text-foreground text-sm leading-[23px] font-medium md:text-base md:leading-[26px]"
+                    >
+                      รหัสเชิญ <span className="text-error">*</span>
+                    </label>
+                    <Input
+                      id="invitationCode"
+                      placeholder="กรอกรหัสเชิญ"
+                      autoComplete="off"
+                      error={!!errors.invitationCode}
+                      errorMessage={errors.invitationCode?.message}
+                      {...register("invitationCode")}
+                    />
+                  </div>
 
-              <div className="flex flex-col gap-4">
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="invitationCode"
-                    className="font-ibm-plex text-foreground text-sm leading-[23px] font-medium md:text-base md:leading-[26px]"
-                  >
-                    รหัสเชิญ <span className="text-error">*</span>
-                  </label>
-                  <Input
-                    id="invitationCode"
-                    name="invitationCode"
-                    placeholder="กรอกรหัสเชิญ"
-                    autoComplete="off"
-                    required
-                  />
+                  <div className="flex flex-col gap-1">
+                    <label
+                      htmlFor="email"
+                      className="font-ibm-plex text-foreground text-sm leading-[23px] font-medium md:text-base md:leading-[26px]"
+                    >
+                      อีเมล <span className="text-error">*</span>
+                    </label>
+                    <Input
+                      id="email"
+                      type="email"
+                      autoComplete="email"
+                      placeholder="example@gmail.com"
+                      error={!!errors.email}
+                      errorMessage={errors.email?.message}
+                      {...register("email")}
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-1">
+                    <label
+                      htmlFor="password"
+                      className="font-ibm-plex text-foreground text-sm leading-[23px] font-medium md:text-base md:leading-[26px]"
+                    >
+                      รหัสผ่าน <span className="text-error">*</span>
+                    </label>
+                    <PasswordInput
+                      id="password"
+                      autoComplete="new-password"
+                      placeholder="กรอกรหัสผ่าน"
+                      error={!!errors.password}
+                      errorMessage={errors.password?.message}
+                      {...register("password")}
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-1">
+                    <label
+                      htmlFor="confirmPassword"
+                      className="font-ibm-plex text-foreground text-sm leading-[23px] font-medium md:text-base md:leading-[26px]"
+                    >
+                      ยืนยันรหัสผ่าน <span className="text-error">*</span>
+                    </label>
+                    <PasswordInput
+                      id="confirmPassword"
+                      autoComplete="new-password"
+                      placeholder="กรอกรหัสผ่านอีกครั้ง"
+                      error={!!errors.confirmPassword}
+                      errorMessage={errors.confirmPassword?.message}
+                      {...register("confirmPassword")}
+                    />
+                  </div>
+
+                  <Button type="submit" className="w-full" isLoading={isSubmitting}>
+                    ถัดไป
+                  </Button>
+
+                  <p className="text-foreground-secondary text-center text-sm font-medium">
+                    มีบัญชีอยู่แล้ว?{" "}
+                    <Link href="/login" className="text-primary font-medium">
+                      เข้าสู่ระบบ
+                    </Link>
+                  </p>
                 </div>
-
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="email"
-                    className="font-ibm-plex text-foreground text-sm leading-[23px] font-medium md:text-base md:leading-[26px]"
-                  >
-                    อีเมล <span className="text-error">*</span>
-                  </label>
-                  <Input
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    placeholder="example@gmail.com"
-                    required
-                  />
-                </div>
-
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="password"
-                    className="font-ibm-plex text-foreground text-sm leading-[23px] font-medium md:text-base md:leading-[26px]"
-                  >
-                    รหัสผ่าน <span className="text-error">*</span>
-                  </label>
-                  <PasswordInput
-                    id="password"
-                    name="password"
-                    autoComplete="new-password"
-                    placeholder="กรอกรหัสผ่าน"
-                    required
-                  />
-                </div>
-
-                <div className="flex flex-col gap-1">
-                  <label
-                    htmlFor="confirmPassword"
-                    className="font-ibm-plex text-foreground text-sm leading-[23px] font-medium md:text-base md:leading-[26px]"
-                  >
-                    ยืนยันรหัสผ่าน <span className="text-error">*</span>
-                  </label>
-                  <PasswordInput
-                    id="confirmPassword"
-                    name="confirmPassword"
-                    autoComplete="new-password"
-                    placeholder="กรอกรหัสผ่านอีกครั้ง"
-                    required
-                  />
-                </div>
-
-                <Button type="submit" className="w-full">
-                  ถัดไป
-                </Button>
-
-                <p className="text-foreground-secondary text-center text-sm font-medium">
-                  มีบัญชีอยู่แล้ว?{" "}
-                  <Link href="/login" className="text-primary font-medium">
-                    เข้าสู่ระบบ
-                  </Link>
-                </p>
-              </div>
+              </fieldset>
             </form>
           </CardContent>
         </Card>

--- a/src/app/register/register-schema.test.ts
+++ b/src/app/register/register-schema.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONFIRM_PASSWORD_MISMATCH_MESSAGE,
+  CONFIRM_PASSWORD_REQUIRED_MESSAGE,
+  EMAIL_INVALID_MESSAGE,
+  EMAIL_REQUIRED_MESSAGE,
+  INVITATION_CODE_REQUIRED_MESSAGE,
+  PASSWORD_FORMAT_MESSAGE,
+  PASSWORD_REQUIRED_MESSAGE,
+  registerClubSchema,
+} from "./register-schema";
+
+const validInput = {
+  invitationCode: "ABC123",
+  email: "club@gmail.com",
+  password: "password1",
+  confirmPassword: "password1",
+};
+
+const firstMessage = (result: ReturnType<typeof registerClubSchema.safeParse>) => {
+  if (result.success) throw new Error("expected validation to fail");
+  return result.error.issues[0]?.message;
+};
+
+describe("registerClubSchema", () => {
+  it("accepts valid input", () => {
+    const result = registerClubSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it("trims the invitation code and email", () => {
+    const result = registerClubSchema.safeParse({
+      ...validInput,
+      invitationCode: "  ABC123  ",
+      email: "  club@gmail.com  ",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.invitationCode).toBe("ABC123");
+      expect(result.data.email).toBe("club@gmail.com");
+    }
+  });
+
+  it("rejects an empty invitation code", () => {
+    const result = registerClubSchema.safeParse({ ...validInput, invitationCode: "" });
+    expect(firstMessage(result)).toBe(INVITATION_CODE_REQUIRED_MESSAGE);
+  });
+
+  it("rejects an empty email", () => {
+    const result = registerClubSchema.safeParse({ ...validInput, email: "" });
+    expect(firstMessage(result)).toBe(EMAIL_REQUIRED_MESSAGE);
+  });
+
+  it("rejects a malformed email", () => {
+    const result = registerClubSchema.safeParse({ ...validInput, email: "not-an-email" });
+    expect(firstMessage(result)).toBe(EMAIL_INVALID_MESSAGE);
+  });
+
+  it("rejects an empty password", () => {
+    const result = registerClubSchema.safeParse({
+      ...validInput,
+      password: "",
+      confirmPassword: "",
+    });
+    expect(firstMessage(result)).toBe(PASSWORD_REQUIRED_MESSAGE);
+  });
+
+  it("rejects a password shorter than 8 characters", () => {
+    const result = registerClubSchema.safeParse({
+      ...validInput,
+      password: "short1",
+      confirmPassword: "short1",
+    });
+    expect(firstMessage(result)).toBe(PASSWORD_FORMAT_MESSAGE);
+  });
+
+  it("rejects a password containing non-English characters", () => {
+    const result = registerClubSchema.safeParse({
+      ...validInput,
+      password: "รหัสผ่าน1",
+      confirmPassword: "รหัสผ่าน1",
+    });
+    expect(firstMessage(result)).toBe(PASSWORD_FORMAT_MESSAGE);
+  });
+
+  it("accepts an 8-character ASCII password", () => {
+    const result = registerClubSchema.safeParse({
+      ...validInput,
+      password: "abcd1234",
+      confirmPassword: "abcd1234",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty confirm password", () => {
+    const result = registerClubSchema.safeParse({ ...validInput, confirmPassword: "" });
+    expect(firstMessage(result)).toBe(CONFIRM_PASSWORD_REQUIRED_MESSAGE);
+  });
+
+  it("rejects a confirm password that doesn't match", () => {
+    const result = registerClubSchema.safeParse({ ...validInput, confirmPassword: "different1" });
+    expect(firstMessage(result)).toBe(CONFIRM_PASSWORD_MISMATCH_MESSAGE);
+  });
+});

--- a/src/app/register/register-schema.ts
+++ b/src/app/register/register-schema.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+// Same rule as login (see src/app/login/login-schema.ts) — Better Auth's
+// own `minPasswordLength` is 8, and the printable-ASCII check keeps out
+// Thai/other non-English input the form can't guarantee round-trips
+// cleanly. Message copy intentionally matches login's for consistency.
+const PRINTABLE_ASCII_ONLY = /^[\x20-\x7E]*$/;
+
+export const INVITATION_CODE_REQUIRED_MESSAGE = "กรุณากรอกรหัสเชิญ";
+export const EMAIL_REQUIRED_MESSAGE = "กรุณากรอกอีเมล";
+export const EMAIL_INVALID_MESSAGE = "รูปแบบอีเมลไม่ถูกต้อง";
+export const PASSWORD_REQUIRED_MESSAGE = "กรุณากรอกรหัสผ่าน";
+export const PASSWORD_FORMAT_MESSAGE = "รหัสผ่านต้องมีอย่างน้อย 8 ตัว และใช้ตัวอักษรอังกฤษเท่านั้น";
+export const CONFIRM_PASSWORD_REQUIRED_MESSAGE = "กรุณายืนยันรหัสผ่าน";
+export const CONFIRM_PASSWORD_MISMATCH_MESSAGE = "รหัสผ่านไม่ตรงกัน";
+
+// Server-driven cases from #92's acceptance criteria — not part of this
+// schema, since neither is checkable without a network round trip. Defined
+// here now so the copy is settled; #97/#98 wire the actual API call and
+// attach these via react-hook-form's setError, the same way login-schema.ts's
+// classifyAuthError maps an async failure onto a field.
+export const CODE_EMAIL_MISMATCH_MESSAGE = "อีเมลหรือรหัสเชิญไม่ถูกต้อง";
+export const EMAIL_ALREADY_USED_MESSAGE = "อีเมลนี้ถูกใช้ไปแล้ว";
+
+export const registerClubSchema = z
+  .object({
+    invitationCode: z.string().trim().min(1, INVITATION_CODE_REQUIRED_MESSAGE),
+    email: z.string().trim().min(1, EMAIL_REQUIRED_MESSAGE).email(EMAIL_INVALID_MESSAGE),
+    password: z
+      .string()
+      .min(1, PASSWORD_REQUIRED_MESSAGE)
+      .refine(
+        (value) => value.length >= 8 && PRINTABLE_ASCII_ONLY.test(value),
+        PASSWORD_FORMAT_MESSAGE
+      ),
+    confirmPassword: z.string().min(1, CONFIRM_PASSWORD_REQUIRED_MESSAGE),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: CONFIRM_PASSWORD_MISMATCH_MESSAGE,
+    path: ["confirmPassword"],
+  });
+
+export type RegisterClubFormValues = z.infer<typeof registerClubSchema>;


### PR DESCRIPTION
Adds zod schema validation to the register form (#93), building on #92.
- required fields, email format, password rules (same as login: ≥8 chars, English-only), confirm-password match
- wired via react-hook-form + zodResolver, same pattern as login/page.tsx
- inline error per field, fieldset disables the form while submitting
- code-mismatch / email-already-used messages defined but not wired — need #97/#98's API
