### PR TITLE
feat: 131 complete navbar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,6 +49,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
           userName={session?.user.name}
           userEmail={session?.user.email}
           userRole={session?.user.role}
+          userImage={session?.user.image}
         />
         <TRPCReactProvider>{children}</TRPCReactProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -48,6 +48,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
           isLoggedIn={!!session}
           userName={session?.user.name}
           userEmail={session?.user.email}
+          userRole={session?.user.role}
         />
         <TRPCReactProvider>{children}</TRPCReactProvider>
       </body>

--- a/src/components/Navbar.stories.tsx
+++ b/src/components/Navbar.stories.tsx
@@ -24,6 +24,16 @@ export const LoggedIn: Story = {
     isLoggedIn: true,
     userName: "John Doe",
     userEmail: "example@gmail.com",
+    userRole: "CLUB",
+  },
+};
+
+export const LoggedInStudent: Story = {
+  args: {
+    isLoggedIn: true,
+    userName: "John Doe",
+    userEmail: "example@gmail.com",
+    userRole: "STUDENT",
   },
 };
 

--- a/src/components/Navbar.stories.tsx
+++ b/src/components/Navbar.stories.tsx
@@ -25,6 +25,7 @@ export const LoggedIn: Story = {
     userName: "John Doe",
     userEmail: "example@gmail.com",
     userRole: "CLUB",
+    userImage: "https://placehold.co/80x80",
   },
 };
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,12 +1,29 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Bookmark, Menu, Settings, X } from "lucide-react";
+import Link from "next/link";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { Bookmark, LogOut, Menu, Settings, X } from "lucide-react";
 
-import { Button } from "@/components/ui/Button";
+import { buttonVariants } from "@/components/ui/Button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
+import { cn } from "@/lib/utils";
+import { signOut } from "@/lib/auth-client";
 
-const NAV_LINKS = ["ชมรม", "กิจกรรม", "เกี่ยวกับ"];
+type NavLink = { label: string; href: string | null };
+
+const NAV_LINKS: NavLink[] = [
+  { label: "ชมรม", href: "/clubs" },
+  { label: "กิจกรรม", href: null },
+  { label: "เกี่ยวกับ", href: null },
+];
 
 const FOCUSABLE_SELECTOR =
   'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
@@ -15,12 +32,22 @@ type NavbarProps = {
   isLoggedIn?: boolean;
   userName?: string;
   userEmail?: string;
+  userRole?: string;
 };
 
-export function Navbar({ isLoggedIn = false, userName, userEmail }: NavbarProps) {
+export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: NavbarProps) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const menuToggleRef = useRef<HTMLButtonElement>(null);
   const sidebarRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  const isClub = isLoggedIn && userRole === "CLUB";
+
+  const handleSignOut = async () => {
+    await signOut();
+    router.push("/");
+    router.refresh();
+  };
 
   useEffect(() => {
     if (!isSidebarOpen) return;
@@ -60,47 +87,110 @@ export function Navbar({ isLoggedIn = false, userName, userEmail }: NavbarProps)
     };
   }, [isSidebarOpen]);
 
+  const closeSidebar = () => setIsSidebarOpen(false);
+
   return (
     <nav className="relative flex items-center justify-between bg-white px-4 py-3 md:px-16">
       <div className="md:flex md:items-center">
-        <Image
-          src="/svg/logo.svg"
-          alt="CUatClub"
-          width={76}
-          height={40}
-          priority
-          className="h-7 w-[53px] md:h-10 md:w-[76px]"
-        />
+        <Link href="/" aria-label="CUatClub หน้าแรก">
+          <Image
+            src="/svg/logo.svg"
+            alt="CUatClub"
+            width={76}
+            height={40}
+            priority
+            className="h-7 w-[53px] md:h-10 md:w-[76px]"
+          />
+        </Link>
       </div>
 
       <div className="hidden items-center gap-6 md:absolute md:left-1/2 md:flex md:-translate-x-1/2">
-        {NAV_LINKS.map((label) => (
-          <button
-            key={label}
-            type="button"
-            className="font-ibm-plex text-foreground hover:text-primary cursor-pointer px-4 py-2 text-base font-medium"
-          >
-            {label}
-          </button>
-        ))}
+        {NAV_LINKS.map(({ label, href }) =>
+          href ? (
+            <Link
+              key={label}
+              href={href}
+              className="font-ibm-plex text-foreground hover:text-primary cursor-pointer px-4 py-2 text-base font-medium"
+            >
+              {label}
+            </Link>
+          ) : (
+            <button
+              key={label}
+              type="button"
+              disabled
+              aria-disabled="true"
+              className="font-ibm-plex text-placeholder cursor-not-allowed px-4 py-2 text-base font-medium"
+            >
+              {label}
+            </button>
+          )
+        )}
       </div>
 
       <div className={`hidden items-center justify-end md:flex ${isLoggedIn ? "gap-6" : "gap-3"}`}>
         {isLoggedIn ? (
           <>
-            <Button variant="outline">แดชบอร์ด</Button>
-            <Image
-              src="/svg/user_profile.svg"
-              alt="Profile"
-              width={40}
-              height={40}
-              className="h-10 w-10 rounded-full"
-            />
+            {isClub && (
+              <Link href="/dashboard" className={buttonVariants({ variant: "outline" })}>
+                แดชบอร์ด
+              </Link>
+            )}
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                type="button"
+                aria-label="เมนูผู้ใช้"
+                className="cursor-pointer rounded-full"
+              >
+                <Image
+                  src="/svg/user_profile.svg"
+                  alt="Profile"
+                  width={40}
+                  height={40}
+                  className="h-10 w-10 rounded-full"
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <div className="flex items-center gap-2 pb-2">
+                  <Image
+                    src="/svg/user_profile.svg"
+                    alt="Profile"
+                    width={36}
+                    height={36}
+                    className="h-9 w-9 rounded-full"
+                  />
+                  <div className="flex flex-col">
+                    {userName && (
+                      <span className="font-ibm-plex text-foreground text-sm font-semibold">
+                        {userName}
+                      </span>
+                    )}
+                    {userEmail && (
+                      <span className="font-ibm-plex text-foreground-secondary text-xs">
+                        {userEmail}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onSelect={handleSignOut}
+                  className="text-foreground-secondary hover:text-error focus:text-error data-[highlighted]:text-error"
+                >
+                  <LogOut className="h-4 w-4" />
+                  ออกจากระบบ
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </>
         ) : (
           <>
-            <Button variant="outline">เข้าสู่ระบบ</Button>
-            <Button variant="primary">ลงทะเบียน</Button>
+            <Link href="/login" className={buttonVariants({ variant: "outline" })}>
+              เข้าสู่ระบบ
+            </Link>
+            <Link href="/register" className={buttonVariants({ variant: "primary" })}>
+              ลงทะเบียน
+            </Link>
           </>
         )}
       </div>
@@ -120,7 +210,7 @@ export function Navbar({ isLoggedIn = false, userName, userEmail }: NavbarProps)
         <div className="fixed inset-0 flex md:hidden">
           <div
             className="absolute inset-0 z-20 bg-black/30"
-            onClick={() => setIsSidebarOpen(false)}
+            onClick={closeSidebar}
             aria-hidden="true"
           />
 
@@ -132,21 +222,34 @@ export function Navbar({ isLoggedIn = false, userName, userEmail }: NavbarProps)
             className="animate-in slide-in-from-right z-50 ml-auto flex h-full w-[300px] flex-col bg-white px-5 duration-300"
           >
             <div className="flex h-16 items-center justify-end">
-              <button type="button" aria-label="ปิดเมนู" onClick={() => setIsSidebarOpen(false)}>
+              <button type="button" aria-label="ปิดเมนู" onClick={closeSidebar}>
                 <X className="text-foreground h-5 w-5" />
               </button>
             </div>
 
             <div className="flex flex-col gap-3">
-              {NAV_LINKS.map((label) => (
-                <button
-                  key={label}
-                  type="button"
-                  className="font-ibm-plex text-foreground py-1 text-left text-sm font-medium"
-                >
-                  {label}
-                </button>
-              ))}
+              {NAV_LINKS.map(({ label, href }) =>
+                href ? (
+                  <Link
+                    key={label}
+                    href={href}
+                    onClick={closeSidebar}
+                    className="font-ibm-plex text-foreground py-1 text-left text-sm font-medium"
+                  >
+                    {label}
+                  </Link>
+                ) : (
+                  <button
+                    key={label}
+                    type="button"
+                    disabled
+                    aria-disabled="true"
+                    className="font-ibm-plex text-placeholder cursor-not-allowed py-1 text-left text-sm font-medium"
+                  >
+                    {label}
+                  </button>
+                )
+              )}
             </div>
 
             <div className="border-border my-6 border-t" />
@@ -156,14 +259,18 @@ export function Navbar({ isLoggedIn = false, userName, userEmail }: NavbarProps)
                 <div className="flex flex-col gap-1">
                   <button
                     type="button"
-                    className="font-ibm-plex text-foreground flex items-center gap-2 rounded-lg p-2 text-sm font-medium"
+                    disabled
+                    aria-disabled="true"
+                    className="font-ibm-plex text-placeholder flex cursor-not-allowed items-center gap-2 rounded-lg p-2 text-sm font-medium"
                   >
                     <Bookmark className="h-4 w-4" />
                     ที่บันทึกไว้
                   </button>
                   <button
                     type="button"
-                    className="font-ibm-plex text-foreground flex items-center gap-2 rounded-lg p-2 text-sm font-medium"
+                    disabled
+                    aria-disabled="true"
+                    className="font-ibm-plex text-placeholder flex cursor-not-allowed items-center gap-2 rounded-lg p-2 text-sm font-medium"
                   >
                     <Settings className="h-4 w-4" />
                     ตั้งค่า
@@ -176,7 +283,7 @@ export function Navbar({ isLoggedIn = false, userName, userEmail }: NavbarProps)
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <Image
-                        src="/images/user_profile.svg"
+                        src="/svg/user_profile.svg"
                         alt="Profile"
                         width={36}
                         height={36}
@@ -197,25 +304,40 @@ export function Navbar({ isLoggedIn = false, userName, userEmail }: NavbarProps)
                     </div>
                     <button
                       type="button"
-                      className="font-ibm-plex text-foreground-secondary text-[10px]"
+                      onClick={handleSignOut}
+                      className="font-ibm-plex text-foreground-secondary hover:text-error text-[10px]"
                     >
-                      Sign out
+                      ออกจากระบบ
                     </button>
                   </div>
                 )}
 
-                <Button variant="outline" className="mt-6 w-full">
-                  แดชบอร์ด
-                </Button>
+                {isClub && (
+                  <Link
+                    href="/dashboard"
+                    onClick={closeSidebar}
+                    className={cn(buttonVariants({ variant: "outline" }), "mt-6 w-full")}
+                  >
+                    แดชบอร์ด
+                  </Link>
+                )}
               </>
             ) : (
               <div className="flex flex-col gap-3">
-                <Button variant="primary" className="w-full">
+                <Link
+                  href="/register"
+                  onClick={closeSidebar}
+                  className={cn(buttonVariants({ variant: "primary" }), "w-full")}
+                >
                   ลงทะเบียน
-                </Button>
-                <Button variant="outline" className="w-full">
+                </Link>
+                <Link
+                  href="/login"
+                  onClick={closeSidebar}
+                  className={cn(buttonVariants({ variant: "outline" }), "w-full")}
+                >
                   เข้าสู่ระบบ
-                </Button>
+                </Link>
               </div>
             )}
           </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { Bookmark, LogOut, Menu, Settings, X } from "lucide-react";
 
 import { buttonVariants } from "@/components/ui/Button";
@@ -33,13 +33,22 @@ type NavbarProps = {
   userName?: string;
   userEmail?: string;
   userRole?: string;
+  userImage?: string | null;
 };
 
-export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: NavbarProps) {
+export function Navbar({
+  isLoggedIn = false,
+  userName,
+  userEmail,
+  userRole,
+  userImage,
+}: NavbarProps) {
+  const profileImageSrc = userImage ?? "/svg/user_profile.svg";
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const menuToggleRef = useRef<HTMLButtonElement>(null);
   const sidebarRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
+  const pathname = usePathname();
 
   const isClub = isLoggedIn && userRole === "CLUB";
 
@@ -90,7 +99,7 @@ export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: Na
   const closeSidebar = () => setIsSidebarOpen(false);
 
   return (
-    <nav className="relative flex items-center justify-between bg-white px-4 py-3 md:px-16">
+    <nav className="sticky top-0 z-30 flex items-center justify-between bg-white px-4 py-3 shadow-black md:px-16">
       <div className="md:flex md:items-center">
         <Link href="/" aria-label="CUatClub หน้าแรก">
           <Image
@@ -105,12 +114,17 @@ export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: Na
       </div>
 
       <div className="hidden items-center gap-6 md:absolute md:left-1/2 md:flex md:-translate-x-1/2">
-        {NAV_LINKS.map(({ label, href }) =>
-          href ? (
+        {NAV_LINKS.map(({ label, href }) => {
+          const isActive = href !== null && pathname === href;
+
+          return href ? (
             <Link
               key={label}
               href={href}
-              className="font-ibm-plex text-foreground hover:text-primary cursor-pointer px-4 py-2 text-base font-medium"
+              className={cn(
+                "font-ibm-plex after:bg-primary hover:text-primary relative cursor-pointer px-4 py-2 text-base font-medium after:absolute after:right-4 after:-bottom-3 after:left-4 after:h-1 after:rounded-full after:transition-transform after:content-[''] hover:after:scale-x-100",
+                isActive ? "text-primary after:scale-x-100" : "text-foreground after:scale-x-0"
+              )}
             >
               {label}
             </Link>
@@ -124,8 +138,8 @@ export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: Na
             >
               {label}
             </button>
-          )
-        )}
+          );
+        })}
       </div>
 
       <div className={`hidden items-center justify-end md:flex ${isLoggedIn ? "gap-6" : "gap-3"}`}>
@@ -143,7 +157,7 @@ export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: Na
                 className="cursor-pointer rounded-full"
               >
                 <Image
-                  src="/svg/user_profile.svg"
+                  src={profileImageSrc}
                   alt="Profile"
                   width={40}
                   height={40}
@@ -153,7 +167,7 @@ export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: Na
               <DropdownMenuContent>
                 <div className="flex items-center gap-2 pb-2">
                   <Image
-                    src="/svg/user_profile.svg"
+                    src={profileImageSrc}
                     alt="Profile"
                     width={36}
                     height={36}
@@ -175,7 +189,7 @@ export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: Na
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onSelect={handleSignOut}
-                  className="text-foreground-secondary hover:text-error focus:text-error data-[highlighted]:text-error"
+                  className="text-foreground-secondary bg-text-error hover:text-error focus:text-error data-[highlighted]:text-error data-[highlighted]:bg-tag-red-light"
                 >
                   <LogOut className="h-4 w-4" />
                   ออกจากระบบ
@@ -228,13 +242,18 @@ export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: Na
             </div>
 
             <div className="flex flex-col gap-3">
-              {NAV_LINKS.map(({ label, href }) =>
-                href ? (
+              {NAV_LINKS.map(({ label, href }) => {
+                const isActive = href !== null && pathname === href;
+
+                return href ? (
                   <Link
                     key={label}
                     href={href}
                     onClick={closeSidebar}
-                    className="font-ibm-plex text-foreground py-1 text-left text-sm font-medium"
+                    className={cn(
+                      "font-ibm-plex py-1 text-left text-sm font-medium",
+                      isActive ? "text-primary" : "text-foreground"
+                    )}
                   >
                     {label}
                   </Link>
@@ -248,8 +267,8 @@ export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: Na
                   >
                     {label}
                   </button>
-                )
-              )}
+                );
+              })}
             </div>
 
             <div className="border-border my-6 border-t" />
@@ -283,7 +302,7 @@ export function Navbar({ isLoggedIn = false, userName, userEmail, userRole }: Na
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <Image
-                        src="/svg/user_profile.svg"
+                        src={profileImageSrc}
                         alt="Profile"
                         width={36}
                         height={36}

--- a/src/components/ui/DropdownMenu.stories.tsx
+++ b/src/components/ui/DropdownMenu.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { LogOut } from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./DropdownMenu";
+
+const meta = {
+  title: "UI/DropdownMenu",
+  component: DropdownMenu,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof DropdownMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ProfileMenu: Story = {
+  render: () => (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger
+        type="button"
+        className="font-ibm-plex text-foreground rounded-full border px-4 py-2 text-sm"
+      >
+        เมนูผู้ใช้
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <div className="flex flex-col pb-2">
+          <span className="font-ibm-plex text-foreground text-sm font-semibold">John Doe</span>
+          <span className="font-ibm-plex text-foreground-secondary text-xs">example@gmail.com</span>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-foreground-secondary hover:text-error data-[highlighted]:text-error">
+          <LogOut className="h-4 w-4" />
+          ออกจากระบบ
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -1,0 +1,63 @@
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuContent = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 8, align = "end", ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      align={align}
+      className={cn(
+        "z-50 flex w-[230px] flex-col gap-1.5 rounded-[10px] bg-white p-4 shadow-[0px_0px_30px_30px_rgba(0,0,0,0.1)]",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "font-ibm-plex text-foreground flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-sm outline-none select-none",
+      "data-[highlighted]:bg-primary-lighter",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuSeparator = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("bg-border -mx-4 my-1 h-px", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+};

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -15,7 +15,7 @@ const DropdownMenuContent = forwardRef<
       sideOffset={sideOffset}
       align={align}
       className={cn(
-        "z-50 flex w-[230px] flex-col gap-1.5 rounded-[10px] bg-white p-4 shadow-[0px_0px_30px_30px_rgba(0,0,0,0.1)]",
+        "z-50 flex w-[230px] flex-col gap-1.5 rounded-[10px] bg-white p-4 shadow-black",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -2,6 +2,7 @@ export * from "@/components/ui/Button";
 export * from "@/components/ui/Card";
 export * from "@/components/ui/Checkbox";
 export * from "@/components/ui/Dialog";
+export * from "@/components/ui/DropdownMenu";
 export * from "@/components/ui/Input";
 export * from "@/components/ui/MultiSelect";
 export * from "@/components/ui/Pagination";

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,7 +5,7 @@
   --font-th-sarabun: var(--font-th-sarabun), var(--font-en), ui-sans-serif, system-ui, sans-serif;
   --font-ibm-plex: var(--font-ibm-plex), var(--font-en), ui-sans-serif, system-ui, sans-serif;
 
-  --shadow-black: 0px 0px 30px 0px rgba(0, 0, 0, 0.1);
+  --shadow-black: 0px 0px 10px 0px rgba(0, 0, 0, 0.1);
 }
 
 @theme inline {


### PR DESCRIPTION
### Issue ID

Closes #131

### Description

Completes the navbar: wires every item to a real page, makes the right panel
role-aware, adds the profile dropdown, and hooks up logout.

#### Routing

- Logo → `/`, ชมรม → `/clubs`, เข้าสู่ระบบ → `/login`, ลงทะเบียน → `/register`,
  แดชบอร์ด → `/dashboard`.
- Items with no page yet (กิจกรรม, เกี่ยวกับ, and mobile ที่บันทึกไว้ / ตั้งค่า)
  render disabled until those pages exist.

#### Role-aware right panel

- New `userRole` prop, passed from the root layout's session.
- Logged out: เข้าสู่ระบบ + ลงทะเบียน (unchanged).
- Logged in: login/register hidden, profile avatar shown. The แดชบอร์ด button
  appears only for the `CLUB` role; `STUDENT` / `ADMIN` get the avatar only.

#### Profile dropdown

- New `src/components/ui/DropdownMenu.tsx` — shadcn-style wrapper over
  `@radix-ui/react-dropdown-menu` (already a dependency), matching the existing
  `ui/` component conventions. Exported from the barrel, with a stories file.
- Clicking the avatar opens the panel from the Figma spec: name, email, divider,
  ออกจากระบบ. Logout text turns to the `error` colour on hover (`--error` token,
  already in `globals.css` — no CSS change needed).

#### Logout

- Wired to better-auth `signOut()`, then `router.push("/")` + `router.refresh()`,
  mirroring the post-login flow. Applied to both the desktop dropdown and the
  mobile sidebar's logout button (relabelled `Sign out` → ออกจากระบบ).

#### Fixes

- Corrected the mobile profile image path `/images/user_profile.svg` →
  `/svg/user_profile.svg`.

#### Stories

- `Navbar` stories updated: `LoggedIn` now uses `userRole: "CLUB"`; added
  `LoggedInStudent` for the no-dashboard variant.

### Testing

- `tsc --noEmit`: clean on all changed files.
- `prettier --check`: clean on the new files; pre-commit `lint-staged` passed.
- Manual: logged-out links route correctly; disabled items are inert; CLUB user
  sees แดชบอร์ด, STUDENT does not; avatar opens the panel; logout hover shows the
  error colour and clicking it clears the session and returns to `/`; same on
  mobile.

### Out of scope

- Creating `/dashboard`, `/activities`, `/about`, saved, and settings pages.
- The repo-wide CRLF issue (`core.autocrlf=true`, no `.gitattributes`) that makes
  the full `yarn check` fail on untouched files — tracked separately.
